### PR TITLE
Implemented 2FA, made Login/Register check for secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ client.getWebSocketMessages(messageCallback)
 Please see [the open client documentation](https://pushover.net/api/client#download) for information regarding what each message contains. Conditional elements are set to None if they do not exist to prevent exceptions.
 ```
 All Messages Include:
-id, uuid, title, message, app, aid, icon, data, priority
+id, umid, title, message, app, aid, icon, date, priority
 
 Some Messages Conditionally Include: 
 sound, url, url_title, acked, receipt, html

--- a/pushover_open_client/pushover_open_client.py
+++ b/pushover_open_client/pushover_open_client.py
@@ -257,9 +257,12 @@ class Client:
                 'userID': self.userID
                 }, outfile, indent=4)
 
-    def login(self, force=False):
+    def login(self, twofa=None, force=False):
         """Logs in to an account using supplied information in configuration"""
         payload = {}
+
+        if twofa != None:
+            self.twofa = twofa
 
         if self.secret != None and self.secret != "" and force == False:
             return

--- a/pushover_open_client/pushover_open_client.py
+++ b/pushover_open_client/pushover_open_client.py
@@ -214,23 +214,34 @@ class Client:
         """TODO: Add possible global timeouts for certain functions to prevent
         spamming of gets/posts"""
 
+        self.email = email
+        self.password = password
+        self.twofa = twofa
+        self.secret = None
+        self.deviceID = None
+        self.userID = None
+
         if configFile is not None:
             with open(configFile, 'r') as infile:
                 jsonConfig = json.load(infile)
 
-            self.email = jsonConfig["email"]
-            self.password = jsonConfig["password"]
+            if "email" in jsonConfig:
+                self.email = jsonConfig["email"]
+
+            if "password" in jsonConfig:
+                self.password = jsonConfig["password"]
 
             if "twofa" in jsonConfig:
                 self.twofa = jsonConfig["twofa"]
 
-            self.secret = jsonConfig["secret"]
-            self.deviceID = jsonConfig["deviceID"]
-            self.userID = jsonConfig["userID"]
-        else:
-            self.email = email
-            self.password = password
-            self.twofa = twofa
+            if "secret" in jsonConfig:
+                self.secret = jsonConfig["secret"]
+
+            if "deviceID" in jsonConfig:
+                self.deviceID = jsonConfig["deviceID"]
+
+            if "userID" in jsonConfig:
+                self.userID = jsonConfig["userID"]
 
         self.websocket = WSClient(self)
 


### PR DESCRIPTION
This PR allows people with 2FA enabled on their account to log in initially by providing the 2FA code within the .cfg file as `twofa`.

Later on, the code now checks whether there is a secret set already and uses that one to work with, instead of logging in every single time. Also, device registration won't run if there's already a secret set.